### PR TITLE
GHI #15 Make CMake naming consistent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(patomic::patomic ALIAS patomic_patomic)
 # ---- Generate Build Info Headers ----
 
 # used in export header generated below
-if(NOT patomic_BUILD_SHARED)
+if(NOT PATOMIC_BUILD_SHARED)
     target_compile_definitions(patomic_patomic PUBLIC PATOMIC_STATIC_DEFINE)
 endif()
 
@@ -83,7 +83,7 @@ endif()
 
 # ---- Setup Tests ----
 
-if(patomic_BUILD_TESTING)
+if(PATOMIC_BUILD_TESTING)
     # need to enable testing in case BUILD_TESTING is disabled
     enable_testing()
     add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include(cmake/util/OptionVariables.cmake)
 
 add_library(
     patomic_patomic
-    ${patomic_BUILD_TYPE}
+    ${build_type}
     # include
     include/patomic/patomic.h
     # src
@@ -66,7 +66,7 @@ target_include_directories(
 
 # header files from /include
 target_include_directories(
-    patomic_patomic ${patomic_WARNING_GUARD}
+    patomic_patomic ${warning_guard}
     PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
 )

--- a/cmake/util/InstallRules.cmake
+++ b/cmake/util/InstallRules.cmake
@@ -1,10 +1,3 @@
-if(PROJECT_IS_TOP_LEVEL)
-    set(
-        CMAKE_INSTALL_INCLUDEDIR "include/patomic-${PROJECT_VERSION}"
-        CACHE PATH ""
-    )
-endif()
-
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
@@ -34,13 +27,6 @@ install(
     INCLUDES #
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
-
-# allow package maintainers to freely override the path for the configs
-set(
-    PATOMIC_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${package}"
-    CACHE PATH "CMake package config location relative to the install prefix"
-)
-mark_as_advanced(PATOMIC_INSTALL_CMAKEDIR)
 
 # copy config file for find_package to find
 install(

--- a/cmake/util/InstallRules.cmake
+++ b/cmake/util/InstallRules.cmake
@@ -37,15 +37,15 @@ install(
 
 # allow package maintainers to freely override the path for the configs
 set(
-    patomic_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${package}"
+    PATOMIC_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${package}"
     CACHE PATH "CMake package config location relative to the install prefix"
 )
-mark_as_advanced(patomic_INSTALL_CMAKE_DIR)
+mark_as_advanced(PATOMIC_INSTALL_CMAKEDIR)
 
 # copy config file for find_package to find
 install(
     FILES "${PROJECT_SOURCE_DIR}/cmake/util/InstallConfig.cmake"
-    DESTINATION "${patomic_INSTALL_CMAKEDIR}"
+    DESTINATION "${PATOMIC_INSTALL_CMAKEDIR}"
     RENAME "${package}Config.cmake"
     COMPONENT patomic_Development
 )
@@ -59,7 +59,7 @@ write_basic_package_version_file(
 # copy version file for find_package to find
 install(
     FILES "${PROJECT_BINARY_DIR}/${package}ConfigVersion.cmake"
-    DESTINATION "${patomic_INSTALL_CMAKEDIR}"
+    DESTINATION "${PATOMIC_INSTALL_CMAKEDIR}"
     COMPONENT patomic_Development
 )
 
@@ -67,7 +67,7 @@ install(
 install(
     EXPORT patomicTargets
     NAMESPACE patomic::
-    DESTINATION "${patomic_INSTALL_CMAKEDIR}"
+    DESTINATION "${PATOMIC_INSTALL_CMAKEDIR}"
     COMPONENT patomic_Development
 )
 

--- a/cmake/util/OptionVariables.cmake
+++ b/cmake/util/OptionVariables.cmake
@@ -11,9 +11,9 @@ option(
     ${BUILD_SHARED_LIBS}
 )
 mark_as_advanced(PATOMIC_BUILD_SHARED)
-set(patomic_BUILD_TYPE STATIC)
+set(build_type STATIC)
 if(PATOMIC_BUILD_SHARED)
-    set(patomic_BUILD_TYPE SHARED)
+    set(build_type SHARED)
 endif()
 
 
@@ -23,7 +23,7 @@ endif()
 # omit warnings from the provided paths, if the compiler supports that.
 # This is to provide a user experience similar to find_package when
 # add_subdirectory or FetchContent is used to consume this project.
-set(patomic_WARNING_GUARD "")
+set(warning_guard "")
 if(NOT PROJECT_IS_TOP_LEVEL)
     option(
         PATOMIC_INCLUDES_WITH_SYSTEM
@@ -32,7 +32,7 @@ if(NOT PROJECT_IS_TOP_LEVEL)
     )
     mark_as_advanced(PATOMIC_INCLUDES_WITH_SYSTEM)
     if(PATOMIC_INCLUDES_WITH_SYSTEM)
-        set(patomic_WARNING_GUARD SYSTEM)
+        set(warning_guard SYSTEM)
     endif()
 endif()
 

--- a/cmake/util/OptionVariables.cmake
+++ b/cmake/util/OptionVariables.cmake
@@ -52,3 +52,27 @@ option(
     ${BUILD_TESTING}
 )
 mark_as_advanced(PATOMIC_BUILD_TESTING)
+
+
+# ---- Install Include Directory ----
+
+# Adds an extra directory to the include path by default, so that when you link
+# against the target, you get `<prefix>/include/patomic-X.Y.Z` added to your
+# include paths rather than `<prefix/include`.
+if(PROJECT_IS_TOP_LEVEL)
+    set(
+        CMAKE_INSTALL_INCLUDEDIR "include/patomic-${PROJECT_VERSION}"
+        CACHE PATH ""
+    )
+endif()
+
+
+# ---- Install CMake Directory ----
+
+# This allows package maintainers to freely override the installation path for
+# the CMake configs.
+set(
+    PATOMIC_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${package}"
+    CACHE PATH "CMake package config location relative to the install prefix"
+)
+mark_as_advanced(PATOMIC_INSTALL_CMAKEDIR)

--- a/cmake/util/OptionVariables.cmake
+++ b/cmake/util/OptionVariables.cmake
@@ -6,13 +6,13 @@ if(PROJECT_IS_TOP_LEVEL)
     option(BUILD_SHARED_LIBS "Build shared libs" OFF)
 endif()
 option(
-    patomic_BUILD_SHARED
+    PATOMIC_BUILD_SHARED
     "Override BUILD_SHARED_LIBS for patomic library"
     ${BUILD_SHARED_LIBS}
 )
-mark_as_advanced(patomic_BUILD_SHARED)
+mark_as_advanced(PATOMIC_BUILD_SHARED)
 set(patomic_BUILD_TYPE STATIC)
-if(patomic_BUILD_SHARED)
+if(PATOMIC_BUILD_SHARED)
     set(patomic_BUILD_TYPE SHARED)
 endif()
 
@@ -26,12 +26,12 @@ endif()
 set(patomic_WARNING_GUARD "")
 if(NOT PROJECT_IS_TOP_LEVEL)
     option(
-        patomic_INCLUDES_WITH_SYSTEM
+        PATOMIC_INCLUDES_WITH_SYSTEM
         "Use SYSTEM modifier for patomic's includes, disabling warnings"
         ON
     )
-    mark_as_advanced(patomic_INCLUDES_WITH_SYSTEM)
-    if(patomic_INCLUDES_WITH_SYSTEM)
+    mark_as_advanced(PATOMIC_INCLUDES_WITH_SYSTEM)
+    if(PATOMIC_INCLUDES_WITH_SYSTEM)
         set(patomic_WARNING_GUARD SYSTEM)
     endif()
 endif()
@@ -47,8 +47,8 @@ if(PROJECT_IS_TOP_LEVEL)
     option(BUILD_TESTING "Build tests" OFF)
 endif()
 option(
-    patomic_BUILD_TESTING
+    PATOMIC_BUILD_TESTING
     "Override BUILD_TESTING for patomic library"
     ${BUILD_TESTING}
 )
-mark_as_advanced(patomic_BUILD_TESTING)
+mark_as_advanced(PATOMIC_BUILD_TESTING)

--- a/test/cmake/CreateTest.cmake
+++ b/test/cmake/CreateTest.cmake
@@ -83,8 +83,8 @@ function(create_test)
     set(target_deps patomic::patomic GTest::gtest_main ${ARG_LINK})
     set(output_name ${name})
 
-    if (NOT "${target}" MATCHES ${patomic_test_CREATE_TEST_TARGETS_MATCHING})
-        message(DEBUG "Skipping creation of test target ${target} (matches ${patomic_test_CREATE_TEST_TARGETS_MATCHING})")
+    if (NOT "${target}" MATCHES ${PATOMIC_CREATE_TEST_TARGETS_MATCHING})
+        message(DEBUG "Skipping creation of test target ${target} (matches ${PATOMIC_CREATE_TEST_TARGETS_MATCHING})")
         return()
     endif()
 
@@ -119,7 +119,7 @@ function(create_test)
     if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
 
         # check we actually care about Windows PATH stuff
-        if (NOT patomic_test_SET_CTEST_PATH_ENV_WINDOWS AND NOT patomic_test_CREATE_WINDOWS_PATH_FILE)
+        if (NOT PATOMIC_WINDOWS_SET_CTEST_PATH_ENV AND NOT PATOMIC_WINDOWS_CREATE_PATH_ENV_FILE)
             return()
         endif()
 
@@ -130,7 +130,7 @@ function(create_test)
         )
 
         # set environment variable for the each test so that CTest works automatically
-        if (deps_path AND patomic_test_SET_CTEST_PATH_ENV_WINDOWS)
+        if (deps_path AND PATOMIC_WINDOWS_SET_CTEST_PATH_ENV)
             foreach(test IN LISTS added_tests)
                 set_property(
                     TEST "${test}"
@@ -140,7 +140,7 @@ function(create_test)
         endif()
 
         # make dependencies accessible from parent target
-        if (patomic_test_CREATE_WINDOWS_PATH_FILE)
+        if (PATOMIC_WINDOWS_CREATE_PATH_ENV_FILE)
             set_property(
                 TARGET ${parent_target}
                 APPEND PROPERTY WIN_DEP_TARGETS ${target_deps}
@@ -194,7 +194,7 @@ function(create_test_win_deps_path_file ARG_KIND)
 
     # check we actually want to generate file
 
-    if(NOT patomic_test_CREATE_WINDOWS_PATH_FILE)
+    if(NOT PATOMIC_WINDOWS_CREATE_PATH_ENV_FILE)
         return()
     endif()
 

--- a/test/cmake/OptionVariables.cmake
+++ b/test/cmake/OptionVariables.cmake
@@ -20,7 +20,7 @@ set(
 # Regex must be written according to CMake Regex Specification.
 # By default all test targets are enabled.
 set(
-    patomic_test_CREATE_TEST_TARGETS_MATCHING "^(.*)$"
+    PATOMIC_CREATE_TEST_TARGETS_MATCHING "^(.*)$"
     CACHE STRING "Only test targets matching regex are created and registered with CTest"
 )
 
@@ -33,11 +33,11 @@ set(
 # than prepend to it.
 # This gives users the option to disable this behaviour.
 option(
-    patomic_test_SET_CTEST_PATH_ENV_WINDOWS
+    PATOMIC_WINDOWS_SET_CTEST_PATH_ENV
     "Set PATH environment variable for tests when run CTest on Windows"
     ON
 )
-mark_as_advanced(patomic_test_SET_CTEST_PATH_ENV_WINDOWS)
+mark_as_advanced(PATOMIC_WINDOWS_SET_CTEST_PATH_ENV)
 
 
 # ---- Windows Path File ----
@@ -50,8 +50,8 @@ mark_as_advanced(patomic_test_SET_CTEST_PATH_ENV_WINDOWS)
 # Additionally disabled by default because it contains potentially private
 # information about the target platform.
 option(
-    patomic_test_CREATE_WINDOWS_PATH_FILE
+    PATOMIC_WINDOWS_CREATE_PATH_ENV_FILE
     "Create file with PATH environment variables for tests on Windows"
     OFF
 )
-mark_as_advanced(patomic_test_CREATE_WINDOWS_PATH_FILE)
+mark_as_advanced(PATOMIC_WINDOWS_CREATE_PATH_ENV_FILE)

--- a/test/cmake/WindowsDependenciesPath.cmake
+++ b/test/cmake/WindowsDependenciesPath.cmake
@@ -6,9 +6,9 @@
 # path in order to find linked dependencies
 # See: https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order
 # Usage: windows_deps_path(<variable> <link-target>...)
-function(windows_deps_path VAR)
+function(windows_deps_path ARG_VAR)
     if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
-        set(${VAR} "" PARENT_SCOPE)
+        set(${ARG_VAR} "" PARENT_SCOPE)
         return()
     endif()
 
@@ -35,5 +35,5 @@ function(windows_deps_path VAR)
         set(glue "\;")  # backslash is important
     endforeach()
 
-    set(${VAR} "${path}" PARENT_SCOPE)
+    set(${ARG_VAR} "${path}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
## Scope

- make `patomic_` options all-caps
- make `patomic_test_` options all-caps, rename slightly, and remove `test` from prefix
- make project scope variables snake-case and remove `patomic_` prefix
- prefix argument names with `ARG_`
- move all options to the relevant `OptionVariables.cmake`